### PR TITLE
Add OpenCode GitHub integration

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,27 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run opencode
+        uses: sst/opencode/github@latest
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          model: anthropic/claude-opus-4-1-20250805


### PR DESCRIPTION
## Summary
- Add OpenCode workflow to enable AI assistance via issue comments
- Configure authentication using ANTHROPIC_API_KEY (works with Claude Max free credits)

## Changes
- Added `.github/workflows/opencode.yml` workflow that:
  - Triggers on `/oc` or `/opencode` commands in issue comments
  - Uses API key authentication (compatible with Claude Max $5/month free credits)
  - Runs claude-opus model to assist with code tasks

## Setup Required
After merging, add the `ANTHROPIC_API_KEY` secret to the repository:
```bash
gh secret set ANTHROPIC_API_KEY --repo Yabonev/phone-to-laptop
```

## Testing
Once merged and secret is set, test by commenting `/oc hello` on any issue.